### PR TITLE
WMTS tile layer implementation and lint errors

### DIFF
--- a/packages/react-components/src/lib/ol-map/map.tsx
+++ b/packages/react-components/src/lib/ol-map/map.tsx
@@ -8,9 +8,11 @@ import React, {
 import { Map as OlMap, View } from 'ol';
 import './map.css';
 import 'ol/ol.css';
-import { format } from "ol/coordinate";
+import { format, Coordinate } from "ol/coordinate";
 import { defaults as defaultControls, FullScreen } from "ol/control";
 import MousePosition from "ol/control/MousePosition";
+import Collection from 'ol/Collection';
+import Control from 'ol/control/Control';
 
 export interface MapProps {
   allowFullScreen?: boolean;
@@ -51,8 +53,10 @@ export const Map: React.FC<MapProps> = (props) => {
     })
   );
 
-  const removeControl = (ctrType: any, mapInst: any) => {
-    mapInst.getControls().forEach((control: any) => {
+  // eslint-disable-next-line
+  const removeControl = (ctrType: any, mapInst: OlMap): void => {
+    const controls: Collection<Control> = mapInst.getControls();
+    controls.forEach((control: Control) => {
       if (control instanceof ctrType) {
         mapInst.removeControl(control);
       }
@@ -62,17 +66,17 @@ export const Map: React.FC<MapProps> = (props) => {
   useEffect(() => {
     map.setTarget(mapElementRef.current as HTMLElement);
     
-    if (allowFullScreen != undefined && allowFullScreen) {
+    if (allowFullScreen !== undefined && allowFullScreen) {
       map.addControl(new FullScreen());
     }
     else{
       removeControl(FullScreen, map);
     }
 
-    if (showMousePosition != undefined && showMousePosition) {
+    if (showMousePosition !== undefined && showMousePosition) {
       map.addControl(
         new MousePosition({
-          coordinateFormat: (coord:any)  => format(coord, '{y}°N {x}°E', COORDINATES_FRACTION_DIFITS),
+          coordinateFormat: (coord):string  => format(coord as Coordinate, '{y}°N {x}°E', COORDINATES_FRACTION_DIFITS),
           projection: PROJECTION,
           undefinedHTML: '&nbsp;',
         })

--- a/packages/react-components/src/lib/ol-map/source/index.ts
+++ b/packages/react-components/src/lib/ol-map/source/index.ts
@@ -1,2 +1,3 @@
 export * from './osm';
 export * from './vector-source';
+export * from './wmts';

--- a/packages/react-components/src/lib/ol-map/source/wmts.tsx
+++ b/packages/react-components/src/lib/ol-map/source/wmts.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useTileLayer } from '../layers/tile-layer';
+import { WMTS } from 'ol/source';
+import { Options } from 'ol/source/WMTS';
+import {get as getProjection} from 'ol/proj';
+import WMTSTileGrid from 'ol/tilegrid/WMTS';
+import {getTopLeft, getWidth} from 'ol/extent';
+
+const RESOLUTIONS = 14,
+      TILE_GRANULARITY=256,
+      WMTS_RESOLUTION_BASIS=2;
+
+interface TileWMTSProps {
+  options: Options;
+}
+
+export interface OptionParams {
+  attributions: string;
+  url: string;
+  layer: string;
+  projection: string;
+  format: string;
+  wrapX?: boolean;
+}
+
+export const getWMTSOptions = (params: OptionParams): Options=> {
+  const projection = getProjection(params.projection);
+  const projectionExtent = projection.getExtent();
+  const resolutions = new Array<number>(RESOLUTIONS);
+  const matrixIds = new Array<string>(RESOLUTIONS);
+  const size = getWidth(projectionExtent) / TILE_GRANULARITY;
+  for (let z = 0; z < RESOLUTIONS; ++z) {
+    // generate resolutions and matrixIds arrays for this WMTS
+    resolutions[z] = size / Math.pow(WMTS_RESOLUTION_BASIS, z);
+    matrixIds[z] = z.toString();
+  }
+
+  const wmtsOptions={
+    attributions: params.attributions,
+    url: params.url,
+    layer: params.layer,
+    matrixSet: params.projection,
+    format: params.format,
+    projection: projection,
+    tileGrid: new WMTSTileGrid({
+      origin: getTopLeft(projectionExtent),
+      resolutions: resolutions,
+      matrixIds: matrixIds,
+    }),
+    style: 'default',
+    wrapX: (params.wrapX !== undefined) ? params.wrapX : true,
+  };
+
+  return wmtsOptions;
+
+}
+export const TileWMTS: React.FC<TileWMTSProps> = (props) => {
+  const tileLayer = useTileLayer();
+  const { options } = props;
+
+  useEffect(() => {
+    tileLayer.setSource(new WMTS(options));
+  }, [tileLayer, options]);
+
+  return null;
+};

--- a/packages/react-components/src/lib/ol-map/source/wmts.tsx
+++ b/packages/react-components/src/lib/ol-map/source/wmts.tsx
@@ -15,7 +15,7 @@ interface TileWMTSProps {
 }
 
 export interface OptionParams {
-  attributions: string;
+  attributions?: string;
   url: string;
   layer: string;
   projection: string;


### PR DESCRIPTION
WMTS tile layer params for creation are:
 ```
{
  attributions?: string;
  url: string;
  layer: string;
  projection: string;
  format: string;
  wrapX?: boolean;
}
```