### PR TITLE
Vector tiles support

### DIFF
--- a/packages/react-components/src/lib/map-filter-container/stories/Map.stories.tsx
+++ b/packages/react-components/src/lib/map-filter-container/stories/Map.stories.tsx
@@ -5,7 +5,7 @@ import { MapFilterContainer } from '../map-filter-container';
 import { CSFStory } from '../../utils/story';
 
 export default {
-  title: 'Map',
+  title: 'Container Map',
   component: ContainerMap,
   parameters: {
     layout: 'fullscreen',

--- a/packages/react-components/src/lib/ol-map/layers/vector-tile-layer.tsx
+++ b/packages/react-components/src/lib/ol-map/layers/vector-tile-layer.tsx
@@ -1,0 +1,56 @@
+import React, { useEffect, useState, createContext, useContext } from 'react';
+import VectorTile from 'ol/layer/VectorTile';
+import { Options } from 'ol/layer/Base';
+import { useMap } from '../map';
+import { MapStyle, defaultStyle } from '../style';
+
+export interface VectorTileLayerProps {
+  options?: Options;
+  style?: MapStyle;
+}
+
+const vectorTileLayerContext = createContext<VectorTile | null>(null);
+const VectorTileLayerProvider = vectorTileLayerContext.Provider;
+
+export const useVectorTileLayer = (): VectorTile => {
+  const layer = useContext(vectorTileLayerContext);
+
+  if (layer === null) {
+    throw new Error(
+      'vector tile layer context is null, please check the provider'
+    );
+  }
+
+  return layer;
+};
+
+export const VectorTileLayer: React.FC<VectorTileLayerProps> = ({
+  children,
+  options,
+  style,
+}) => {
+  const map = useMap();
+  const [vectorTileLayer] = useState(
+    new VectorTile({
+      ...options,
+      style: style ? style : defaultStyle,
+    })
+  );
+
+  useEffect(() => {
+    map.addLayer(vectorTileLayer);
+    return (): void => {
+      map.removeLayer(vectorTileLayer);
+    };
+  }, [map, vectorTileLayer]);
+
+  useEffect(() => {
+    vectorTileLayer.setStyle(style ? style : defaultStyle);
+  }, [vectorTileLayer, style]);
+
+  return (
+    <VectorTileLayerProvider value={vectorTileLayer}>
+      {children}
+    </VectorTileLayerProvider>
+  );
+};

--- a/packages/react-components/src/lib/ol-map/source/mvt.tsx
+++ b/packages/react-components/src/lib/ol-map/source/mvt.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, createContext, useContext } from 'react';
+import VectorTileSource, { Options } from 'ol/source/VectorTile';
+import { MVT } from 'ol/format';
+import { useVectorTileLayer } from '../layers/vector-tile-layer';
+
+const vectorSourceContext = createContext<VectorTileSource | null>(null);
+
+export const useVectorSource = (): VectorTileSource => {
+  const source = useContext(vectorSourceContext);
+
+  if (source === null) {
+    throw new Error('vector source context is null, please check the provider');
+  }
+
+  return source;
+};
+
+export interface MVTSourceProps {
+  options: Options;
+}
+
+export interface MVTOptionParams {
+  url: string;
+}
+
+export const getMVTOptions = (optionParams: MVTOptionParams): Options => {
+  const { url } = optionParams;
+  const mvtOptions: Options = {
+    url,
+    format: new MVT(),
+  };
+
+  return mvtOptions;
+};
+
+export const MVTSource: React.FC<MVTSourceProps> = ({ children, options }) => {
+  const vectorTileLayer = useVectorTileLayer();
+
+  useEffect((): void => {
+    vectorTileLayer.setSource(new VectorTileSource(options));
+  }, [options, vectorTileLayer]);
+
+  return null;
+};

--- a/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Meta } from '@storybook/react/types-6-0';
+import { VectorTileLayer } from '../../layers/vector-tile-layer';
+import { Map } from '../../map';
+import { MVTSource, getMVTOptions } from '../mvt';
+import { TileOsm } from '..';
+import { TileLayer } from '../../layers';
+import { Proj } from '../../projections';
+
+export default {
+  title: 'Map Tiles - MVT',
+  component: VectorTileLayer,
+  subcomponents: MVTSource,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+const mapDivStyle = {
+  height: '100%',
+  width: '100%',
+  position: 'absolute' as const,
+};
+
+export const Basic = (): JSX.Element => (
+  <div style={mapDivStyle}>
+    <Map projection={Proj.WEB_MERCATOR}>
+      <TileLayer>
+        <TileOsm />
+      </TileLayer>
+      <VectorTileLayer>
+        <MVTSource
+          options={getMVTOptions({
+            url: 'http://localhost:9090/maps/osm/{z}/{x}/{y}.pbf',
+          })}
+        />
+      </VectorTileLayer>
+    </Map>
+  </div>
+);

--- a/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Meta } from '@storybook/react/types-6-0';
 import { VectorTileLayer } from '../../layers/vector-tile-layer';
 import { Map } from '../../map';
 import { MVTSource, getMVTOptions } from '../mvt';

--- a/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
@@ -19,8 +19,7 @@ const mapDivStyle = {
   position: 'absolute' as const,
 };
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-export const Basic: Story = (args: any) => (
+export const Basic: Story = (args: unknown) => (
   <div style={mapDivStyle}>
     <Map {...args}>
       <TileLayer>

--- a/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
@@ -6,7 +6,7 @@ import { TileLayer } from '../layers';
 import { Proj } from '../projections';
 
 export default {
-  title: 'ol map',
+  title: 'Map',
   component: Map,
   parameters: {
     layout: 'fullscreen',

--- a/packages/react-components/src/lib/ol-map/style.ts
+++ b/packages/react-components/src/lib/ol-map/style.ts
@@ -1,0 +1,24 @@
+import {Fill, Stroke, Circle, Style} from 'ol/style';
+import { StyleFunction } from 'ol/style/Style';
+
+const fill = new Fill({
+  color: 'rgba(255,255,255,0.4)'
+});
+const stroke = new Stroke({
+  color: '#3399CC',
+  width: 1.25
+});
+
+export type MapStyle = Style | Style[] | StyleFunction;
+
+export const defaultStyle = [
+  new Style({
+    image: new Circle({
+      fill: fill,
+      stroke: stroke,
+      radius: 5
+    }),
+    fill: fill,
+    stroke: stroke
+  })
+];

--- a/packages/react-components/src/lib/ol-map/style.ts
+++ b/packages/react-components/src/lib/ol-map/style.ts
@@ -1,12 +1,12 @@
-import {Fill, Stroke, Circle, Style} from 'ol/style';
+import { Fill, Stroke, Circle, Style } from 'ol/style';
 import { StyleFunction } from 'ol/style/Style';
 
 const fill = new Fill({
-  color: 'rgba(255,255,255,0.4)'
+  color: 'rgba(255,255,255,0.4)',
 });
 const stroke = new Stroke({
   color: '#3399CC',
-  width: 1.25
+  width: 1.25,
 });
 
 export type MapStyle = Style | Style[] | StyleFunction;
@@ -16,9 +16,9 @@ export const defaultStyle = [
     image: new Circle({
       fill: fill,
       stroke: stroke,
-      radius: 5
+      radius: 5,
     }),
     fill: fill,
-    stroke: stroke
-  })
+    stroke: stroke,
+  }),
 ];


### PR DESCRIPTION
Related Issues:
https://github.com/MapColonies/vector-layers-catalog/issues/3
Closes issues: 
#39 #40 

## Checklist
- [ ] Tests - not needed
- [x] Stories
- [x] Lint
- [x] Prettier

## What I did

- [ ] BREAKING CHANGE
- [x] feature request
- [ ] bug fix
- [ ] documentation

More information:
added vector tiles layer support to olmap, the story wouldn't work right now because we don't have public source for vector tiles.