### PR TITLE
docs(ol-map): nest sources under same folder in stories

### DIFF
--- a/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/mvt.stories.tsx
@@ -7,7 +7,7 @@ import { TileLayer } from '../../layers';
 import { Proj } from '../../projections';
 
 export default {
-  title: 'Map Tiles - MVT',
+  title: 'Map/Map Tiles/MVT',
   component: VectorTileLayer,
   subcomponents: MVTSource,
   parameters: {

--- a/packages/react-components/src/lib/ol-map/source/stories/wms.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/wms.stories.tsx
@@ -21,11 +21,11 @@ const mapDivStyle = {
 };
 
 export default {
-  title: 'Map Tiles - WMS',
+  title: 'Map/Map Tiles/WMS',
   component: TileWMS,
 };
 
-export const WMS: CSFStory<JSX.Element> = () => (
+export const Basic: CSFStory<JSX.Element> = () => (
   <div style={mapDivStyle}>
     <Map allowFullScreen={true} showMousePosition={true}>
       <TileLayer>
@@ -38,7 +38,7 @@ export const WMS: CSFStory<JSX.Element> = () => (
   </div>
 );
 
-WMS.argTypes = {
+Basic.argTypes = {
   options: {
     description: `{ Options } from 'ol/source/TileWMS'`,
     table: {

--- a/packages/react-components/src/lib/ol-map/source/stories/wmts.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/wmts.stories.tsx
@@ -21,11 +21,11 @@ const mapDivStyle = {
 };
 
 export default {
-  title: 'Map Tiles - WMTS',
+  title: 'Map/Map Tiles/WMTS',
   component: TileWMTS,
 };
 
-export const WMTS: CSFStory<JSX.Element> = () => (
+export const Basic: CSFStory<JSX.Element> = () => (
   <div style={mapDivStyle}>
     <Map allowFullScreen={true} showMousePosition={true}>
       <TileLayer>
@@ -38,7 +38,7 @@ export const WMTS: CSFStory<JSX.Element> = () => (
   </div>
 );
 
-WMTS.argTypes = {
+Basic.argTypes = {
   options: {
     description: `{ Options } from 'ol/source/WMTS'`,
     table: {

--- a/packages/react-components/src/lib/ol-map/source/stories/xyz.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/source/stories/xyz.stories.tsx
@@ -18,11 +18,11 @@ const mapDivStyle = {
 };
 
 export default {
-  title: 'Map Tiles - XYZ',
+  title: 'Map/Map Tiles/XYZ',
   component: TileXYZ,
 };
 
-export const XYZ: CSFStory<JSX.Element> = () => (
+export const Basic: CSFStory<JSX.Element> = () => (
   <div style={mapDivStyle}>
     <Map allowFullScreen={true} showMousePosition={true}>
       <TileLayer>
@@ -35,7 +35,7 @@ export const XYZ: CSFStory<JSX.Element> = () => (
   </div>
 );
 
-XYZ.argTypes = {
+Basic.argTypes = {
   options: {
     description: `{ Options } from 'ol/source/XYZ'`,
     table: {

--- a/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
@@ -19,7 +19,7 @@ const mapDivStyle = {
   position: 'absolute' as const,
 };
 
-export const Basic: Story = (args: unknown) => (
+export const BaseMap: Story = (args: unknown) => (
   <div style={mapDivStyle}>
     <Map {...args}>
       <TileLayer>
@@ -29,7 +29,7 @@ export const Basic: Story = (args: unknown) => (
   </div>
 );
 
-Basic.argTypes = {
+BaseMap.argTypes = {
   projection: {
     defaultValue: Proj.WGS84,
     control: { type: 'radio', options: [Proj.WEB_MERCATOR, Proj.WGS84] },


### PR DESCRIPTION
Related Issues:
#53 
Closes issues: 


## Checklist
- [ ] Tests
- [X] Stories
- [ ] Lint
- [ ] Prettier

## What I did

- [ ] BREAKING CHANGE
- [ ] feature request
- [ ] bug fix
- [X] documentation

More information:
The stories were scattered in the main hierarchy of the storybook page, now they are all under the hierarchy `Map/Map Tiles/{TYPE_OF_SOURCE}`