### PR TITLE
feat(map): zoom and center properties

### DIFF
--- a/packages/react-components/src/lib/ol-map/map.tsx
+++ b/packages/react-components/src/lib/ol-map/map.tsx
@@ -20,6 +20,8 @@ export interface MapProps {
   allowFullScreen?: boolean;
   showMousePosition?: boolean;
   projection?: Proj;
+  center?: [number, number];
+  zoom?: number;
 }
 
 const mapContext = createContext<OlMap | null>(null);
@@ -30,6 +32,12 @@ const CENTER_LAT = 35,
   DEFAULT_ZOOM = 10,
   COORDINATES_WGS_FRACTION_DIGITS = 5,
   COORDINATES_MERCATOR_FRACTION_DIGITS = 2;
+
+const getDefaultCenter = (projection: string | undefined): Coordinate => {
+  return projection !== undefined && projection !== Proj.WGS84
+    ? transform([CENTER_LAT, CENTER_LON], Proj.WGS84, projection)
+    : [CENTER_LAT, CENTER_LON];
+};
 
 const getCoordinateFormatString = (projection?: Proj): CoordinateFormat => {
   switch (projection) {
@@ -69,16 +77,24 @@ export const Map: React.FC<MapProps> = (props) => {
   const [map] = useState(
     new OlMap({
       view: new View({
-        center:
-          projection !== undefined && projection !== Proj.WGS84
-            ? transform([CENTER_LAT, CENTER_LON], Proj.WGS84, projection)
-            : [CENTER_LAT, CENTER_LON],
-        zoom: DEFAULT_ZOOM,
+        // center:
+        //   projection !== undefined && projection !== Proj.WGS84
+        //     ? transform([CENTER_LAT, CENTER_LON], Proj.WGS84, projection)
+        //     : [CENTER_LAT, CENTER_LON],
+        // zoom: DEFAULT_ZOOM,
         projection: projection ?? Proj.WGS84,
       }),
       controls: defaultControls(),
     })
   );
+
+  useEffect(() => {
+    map.getView().setCenter(props.center ?? getDefaultCenter(props.projection));
+  }, [map, props.center, props.projection]);
+
+  useEffect(() => {
+    map.getView().setZoom(props.zoom ?? DEFAULT_ZOOM);
+  }, [map, props.zoom, props.projection]);
 
   // eslint-disable-next-line
   const removeControl = (ctrType: any, mapInst: OlMap): void => {

--- a/packages/react-components/src/lib/ol-map/map.tsx
+++ b/packages/react-components/src/lib/ol-map/map.tsx
@@ -77,11 +77,6 @@ export const Map: React.FC<MapProps> = (props) => {
   const [map] = useState(
     new OlMap({
       view: new View({
-        // center:
-        //   projection !== undefined && projection !== Proj.WGS84
-        //     ? transform([CENTER_LAT, CENTER_LON], Proj.WGS84, projection)
-        //     : [CENTER_LAT, CENTER_LON],
-        // zoom: DEFAULT_ZOOM,
         projection: projection ?? Proj.WGS84,
       }),
       controls: defaultControls(),

--- a/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
@@ -38,4 +38,24 @@ BaseMap.argTypes = {
       options: [Proj.WEB_MERCATOR, Proj.WGS84],
     },
   },
+  zoom: {
+    defaultValue: 3,
+    control: {
+      type: 'range',
+      min: 0,
+      max: 20,
+    },
+  },
 };
+
+export const ConfiguredMap: Story = (args: unknown) => (
+  <div style={mapDivStyle}>
+    <Map zoom={3} center={[0, 0]}>
+      <TileLayer>
+        <TileOsm />
+      </TileLayer>
+    </Map>
+  </div>
+);
+
+ConfiguredMap.storyName = 'with zoom and center';

--- a/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
+++ b/packages/react-components/src/lib/ol-map/stories/map.stories.tsx
@@ -48,7 +48,7 @@ BaseMap.argTypes = {
   },
 };
 
-export const ConfiguredMap: Story = (args: unknown) => (
+export const ConfiguredMap: Story = () => (
   <div style={mapDivStyle}>
     <Map zoom={3} center={[0, 0]}>
       <TileLayer>


### PR DESCRIPTION
Related Issues:

Closes issues: 
#46 
## Checklist
- [ ] Tests
- [x] Stories
- [x] Lint
- [x] Prettier

## What I did

- [ ] BREAKING CHANGE
- [x] feature request
- [ ] bug fix
- [ ] documentation

More information:
The center projection is based on the projection prop of the map, so the value should be accordingly.